### PR TITLE
Added missing 'operator' field to ListQual

### DIFF
--- a/src/main/protobuf/com/rawlabs/protocol/das/tables.proto
+++ b/src/main/protobuf/com/rawlabs/protocol/das/tables.proto
@@ -62,6 +62,7 @@ message SimpleQual {
 message ListQual {
     bool isAny = 1; // If true, it represents an ANY, otherwise it represents an ALL
     repeated com.rawlabs.protocol.raw.Value values = 2;
+    Operator operator = 3;
 }
 
 message Operator {


### PR DESCRIPTION
There's another PR to come towards multicorn-das, that packs the operator to ListQual.