### PR TITLE
refactor(build): remove unecessary resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,10 +18,7 @@ lazy val commonSettings = Seq(
   // Use cached resolution of dependencies
   // http://www.scala-sbt.org/0.13/docs/Cached-Resolution.html
   updateOptions := updateOptions.in(Global).value.withCachedResolution(true),
-  resolvers ++= Seq(Resolver.mavenLocal),
-  resolvers += "RAW Labs GitHub Packages" at "https://maven.pkg.github.com/raw-labs/_",
-  resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
-  resolvers ++= Resolver.sonatypeOssRepos("releases")
+  resolvers += "RAW Labs GitHub Packages" at "https://maven.pkg.github.com/raw-labs/_"
 )
 
 lazy val buildSettings = Seq(


### PR DESCRIPTION
local packages are published to ivy2, we don't publish snapshots on oss anymore and what you find in oss release you might find in maven central which is included by default in resolvers