### PR TITLE
update: bump protobufGrpcVersion to 1.69.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val root = (project in file("."))
     protobufGrpcEnabled := true,
     // Set fixed versions
     ProtobufConfig / version := "3.25.4",
-    ProtobufConfig / protobufGrpcVersion := "1.62.2",
+    ProtobufConfig / protobufGrpcVersion := "1.69.1",
     libraryDependencies ++= Seq(
       // Required for gRPC Protobuf
       "javax.annotation" % "javax.annotation-api" % "1.3.2",


### PR DESCRIPTION
  # gRPC-Java: 1.62.2 to 1.69.1 Update Summary

  ## Summary of Important Changes

  This document summarizes the changes between gRPC-Java versions 1.62.2 and 1.69.1.

  ## Version 1.62.2

  ## gRPC Java 1.62.2 Release Notes
  Note that this is the initial 1.62.x release

  ### API Changes
  - services: Remove `io.grpc.services.BinaryLogs`, which was deprecated since 2021. `io.grpc.protobuf.services.BinaryLogs` should be used instead (#10832).
  - Allow users outside of io.grpc.xds package to create custom xDS resources (#10834) (6d96e6588)

  ### New Features
  - api:Add ClientTransportFilter.  Similarly to ServerTransportFilter, this will provide an observability hook and it allows direct modification of the transport's attributes. (#10646)

  ### Improvements
  - java_grpc_library.bzl: Add support for Auto Exec Groups (cb03bd234). This is mostly a behind-the-scenes change to adjust to the newer way Bazel operates
  - java_grpc_library.bzl: Support runfiles for protoc and the plugin (65a6b3bc2). Neither binary uses runfiles, but the task will be ready if they need to in the future
  - xds: Add EC key support for XdsChannelCredentials/XdsServerCredentials (100d5a55f)
  - binder:Change log level from WARNING to FINER for expected exception during close with error, to reduce log spamming (#10899) (7ba0718bb)

  ### Bug Fixes
    - xds: Fix a bug in WeightedRoundRobinLoadBalancer policy that could raise NullPointerException and further cause channel panic when picking a subchannel. This bug can only be triggered when connection can not be established and the channel reports TRANSIENT_FAILURE state. (#10868)

  ### Dependencies
  - The protoc plugin no longer supports macOS Big Sur (macOS 11). Binaries are now built using Monterey (macOS 12)

  ### Acknowledgements
  - @joybestourous



  ---

  ## Version 1.63.0

  ## API Changes
  - xds: Stabilize CsdsService (#11003) (0d749c594)
  - api: Stabilize server.getListenerSockets (#10910) (ff34d51c7)
  - servlet: Introduce ServletServerBuilder.buildServlet(#10921) (257d1c2db)
  - api: Allow configuration of the queued byte threshold at which a Stream is considered not ready (#10977) (2c83ef063)

  ## New Features
  xds, dual stack, happy eyeballs: Support dual stack in xds, change list includes:
  * Enable new PickFirst lb policy by default. The new PickFirst implements subchannel picking logic.  (#11002) (8a9ce990b)
  * EDS resource now supports additional addresses (#11011) (38f968faf)
  * Change address based outlier detection to endpoint based (#10939) (c61fe6980)
  * Enable Happy Eyeballs by default (#11022) (51f811df8)

  ## Improvements
  - rls: Adding extra debug logs (#10902) (eba699ad1)
  - binder: Add missing Android API annotations (#10841) (ce2adcca9)
  - core: Provide DEADLINE_EXCEEDED insights for context deadline (3abab95e7). When the deadline triggered and the deadline was set on the RPC via the stub or CallOptions, gRPC would gather additional debugging information to help understand where the RPC took so long. However if the deadline came from io.grpc.Context the error was simply “context timed out.” Now the debugging information is provided in both cases
  - examples: Fix file paths in debug example README (e19f1f15a)
  - compiler: implement ability to skip generation of javax annotation (#10927) (0d39c2c70). Pass the option `jakarta_omit` to protoc-gen-grpc-java when generating code
  - xds: Get rid of xDS v2 proto dependencies (#10968) (feab4e544). `grpc-xds` jar size has decreased by 35%.
  - xds: Support retrieving names from wrapped resource containers (#10975) (867e46940)
  - netty: improve server handling of writes to reset streams (#10258) (a68399a9b)
  -  api: Fix a typo in ServerInterceptor JavaDoc (#10990) (0b82f0126)
  - servlet: Check log fine level before hex string conversion. (#11038)
  - auth: Specify a locale for upper/lower case conversions (1.63.x backport) #11050

  ## Bug Fixes
  - xds: Copy data in least request to avoid picker data race (f4cc166f1). This fixes a possible regression introduced in 1.60.0. Auditing the buggy code showed it unlikely to cause problems in practice, but that was more by happenstance than by design
  - xds: Fix data race in the xds client that contacts the control plane (d7628a3ab)
  - rls: Fix a local and remote race (aa9076812). The remote race could cause an RPC to hang until its deadline. It had been seen in practice when the client was severely CPU under-provisioned
  - xds: Fix xdsNameResolver virtual host lookup authority with xdstp style names. Use service authority instead of ldsResourceName (#10960) (78b3972ff)
  -  core: Fix retry race condition that can lead to double decrementing inFlightSubStreams and so miss calling closed (#11026) (#11033)
  - okhttp: Fix OkHTTP client transport leak (#11060)
  - xds: Use empty string when disabling server hostname verification ( #11058)


  ## Dependencies
  - Upgraded google-auth-library-java to 1.22.0

  ## Acknowledgement
  Alex Panchenko 
  Benjamin Peterson
  David Ankin
  Prashanth Swaminathan
  Touko Vainio-Kaila 


  ---

  ## Version 1.63.1

  ## Bug fixes
  - netty: Release SendGrpcFrameCommand when stream is missing (#11116) (fb9a10809)
  - Change defaults to use the older PickFirstLoadBalancer and disable Happy Eyeballs.  This disables a performance optimization added in v1.63.0 (#11120) We have had a report that the new implementation can trigger a NullPointerException



  ---

  ## Version 1.63.2

  ## What's Changed
  * okhttp: Workaround SSLSocket not noticing socket is closed
  * netty: skip using NettyAdaptiveCumulator when Netty is on version 4.1.111 or later


  ---

  ## Version 1.64.0

  _Avoid upgrading your application to Netty 4.1.111, with this version as there is a possible corruption. For Netty 4.1.111 compatibility, it is best to use 1.63.2, 1.64.2, 1.65.1, and later. See https://github.com/grpc/grpc-java/issues/11284 ._

  ## API Changes
  - compiler: the option `jakarta_omit` was renamed `@generated=omit` (#11086) (8a21afcc9)

  ## New Features
  - New API LoadBalancer.getChannelTarget() (4561bb5b8)
  - opentelemetry: Publish new module grpc-opentelemetry (5ba1a5563). The feature is still missing documentation and an example. It only supports metrics; tracing and logs will be future enhancements. See [gRFC A66](https://github.com/grpc/proposal/blob/master/A66-otel-stats.md)
  - bazel: Add support for bzlmod (#11046) (d1890c0ac)
  - bazel: Replace usages of the old compatibility maven targets with `@maven` targets (00649913b)
  - okhttp: Support serverBuilder.maxConcurrentCallsPerConnection (Fixes #11062). (#11063) (805072339)
  - xds: Experimental metrics recording in WRR LB (06df25b65, 35a171bc1, 2897b3939), to be exported by grpc-opentelemetry if explicitly enabled in GrpcOpenTelemetry. See [gRFC A78](https://github.com/grpc/proposal/blob/master/A78-grpc-metrics-wrr-pf-xds.md)
  - rls: Experimental metrics recording in RLS LB (a9fb272b7, a1d19327f, 813331837), to be exported by grpc-opentelemetry if explicitly enabled in GrpcOpenTelemetry

  ## Improvements
  - examples: support bazel build for retry policy example (58de563fa)
  - netty: Allow deframer errors to close stream with a status code, as long as headers have not yet been sent (e036b1b19). This will greatly improve the debuggability of certain server errors in particular cases. Instead of the client seeing “CANCELLED: RST_STREAM closed stream. HTTP/2 error code: CANCEL”, they could see “RESOURCE_EXHAUSTED: gRPC message exceeds maximum size 4194304: 6144592”
  - netty: Improve handling of unexpected write queue promise failures (#11016)
  - servlet: Avoid unnecessary FINEST hex string conversion by checking log level. Fixes #11031. (f7ee5f318)
  - StatusException/StatusRuntimeException hide stack trace in a simpler way (#11064) (e36f099be)
  - util: Status desc for outlier detection ejection (#11036) (10cb4a3be)
  - binder: Helper class to allow in process servers to use peer uids in test (#11014) (537dbe826)
  - Add `load()` statements for the Bazel builtin top-level java symbols (#11105) (add8c37a4)
  - Add `StatusProto.toStatusException` overload to accept `Throwable` (#11083) (5c9b49231)

  ## Bug fixes
  - Fix retry race condition that can lead to double decrementing inFlightSubStreams and so miss calling closed (#11026) (bdb623031)
  - Change defaults to use the older PickFirstLoadBalancer and disable Happy Eyeballs.  This disables a performance optimization added in v1.63. (#11120) We have had a report that the new implementation can trigger a NullPointerException
  - core: Transition to CONNECTING immediately when exiting idle (2c5f0c22c). Previously the visible state change from `channel.getState()` was delayed until the name resolver returned results. This had no impact to RPC behavior
  - xds: Specify a locale for upper/lower case conversions (e6305930d)
  - rls: Synchronization fixes in CachingRlsLbClient (6e97b180b). These races had not been witnessed in practice
  - rls: Guarantee backoff will update RLS picker (f9b6e5f92). This fixes a regression introduced by 6e97b180b that could hang RPCs instead of using fallback, but fixes a pre-existing bug that could greatly delay RPCs from using fallback.
  - rls: Fix time handling in CachingRlsLbClient (da619e2bd). This could have caused backoff entries to improperly be considered expired
  - xds: Properly disable the default endpoint identification algorithm with XdsChannelCredentials (097a46b76). The credential does its own verification and the default needs to be disabled for SPIFFE
  - netty: Release SendGrpcFrameCommand when stream is missing (#11116) (fb9a10809)
  - okhttp: Remove finished stream even if a pending stream was started (d21fe32be)

  ## Dependencies
  - cronet: Update Cronet to latest release + Move to Stable Cronet APIs. (5a8da19f3)
  - cronet: @javadoc update android permission MODIFY_NETWORK_ACCOUNTING (deprecated) => UPDATE_DEVICE_STATS (c703a1ee0)
  - cronet: Update to Java-8 API's and tighten the scopes (163efa371)
  - cronet: Update to StandardCharsets and assertNotNull API's (77e59b29d)

  ## Acknowledgements
  @panchenko
  @Ashok-Varma 
  @benjaminp 
  @AutomatedTester 
  @hypnoce
  @keith 
  @laglangyue 
  @rostik404 
  @ryanpbrewster 
  @abtom 
  @hvadehra 
  @rtadepalli 


  ---

  ## Version 1.64.1

  ## What's Changed
  * netty:Fix Netty composite buffer merging to be compatible with Netty 4.1.111 (1.64.x backport) by @larry-safran in https://github.com/grpc/grpc-java/pull/11303


  ---

  ## Version 1.64.2

  ## What's Changed
  * netty: Restore old behavior of NettyAdaptiveCumulator, but avoid using that class if Netty is on version 4.1.111 or later 

  ---

  ## Version 1.65.0

  grpc-netty in this release is compatible with Netty 4.1.111; it fixes the incompatibility that caused data corruption. grpc-netty-shaded is still using Netty 4.1.100.

  ### New Features
  * New module grpc-gcp-csm-observability (df8cfe9dd)

  ### Improvements
  * api: Add `ClientStreamTracer.inboundHeaders(Metadata)` (960012d76). This is the same as the existing `inboundHeaders()`, but is provided the Metadata
  * api: Fix various typos in the documentation (#11144) (6ec744f2a)
  * core: When queuing RPCs, don’t request picks from the LB twice (8844cf7b8). This could be viewed as a small performance optimization, but mainly reduces the amount of race-handling code
  * util: Improve AdvancedTlsX509KeyManager’s documentation, verification, and testing. (#11139) (781b4c457) This change shows `@ExperimentalApi` being removed, but it was re-added in 3c97245 before the release
  * examples: Fix broken command in reflection readme (#11131) (c31dbf48a)
  * binder: Add a connection timeout (#11255) (791f894e2)

  ### Bug fixes
  * core: Exit idle mode when delayed transport is in use (fea577c80). This was a long-standing race that could cause RPCs to hang, but was very unlikely to be hit. Avoiding the double-picking (8844cf7b8) made the race more visible
  * netty: Fix Netty composite buffer merging to be compatible with Netty 4.1.111 (#11294) (0fea7dd). The previous behavior easily caused data corruption
  * okhttp: Workaround SSLSocket not noticing socket is closed (a28357e19). Previously, shutting down when a new connection was being established could result in the server never becoming terminated
  * inprocess: Fix listener race if transport is shutdown while starting (e4e7f3a06). This issue was unlikely to be hit outside of specialized tests
  * services: restore //services:binarylog bazel target (#11292) (d57f271). This fixes a regression introduced in 1.62.2
  * binder: Wait for all server transports to terminate before returning the security policy executor to the object pool (#11240) (34ee600dc)
  * binder: Reject further SETUP_TRANSPORT requests post-BinderServer shutdown (#11260) (1670e97f7)
  * bazel: Include missing com_google_protobuf_javalite in MODULE.bazel (#11147) (f995c121e)

  ### Thanks to
  @hakusai22
  @firov
  @mateusazis
  @Mir3605
  @niloc132


  ---

  ## Version 1.65.1

  ## What's Changed
  * netty: Restore old behavior of NettyAdaptiveCumulator, but avoid using that class if Netty is on version 4.1.111 or later 

  ---

  ## Version 1.66.0

  ## gRPC Java 1.66.0 Release Notes

  ### API Changes
  * stub: Support setting onReadyThreshold through AbstractStub. (#11320) (25a8b7c50)
  * util: Stabilize `AdvancedTlsX509TrustManager`, an `X509ExtendedTrustManager` that allows users to configure advanced TLS features, such as root certificate reloading and peer cert custom verification. (658cbf6cf)
  * util: Align AdvancedTlsX509{Key and Trust}Manager. (#11385)
  * util: Add `GracefulSwitchLoadBalancer` config (ebed04798) and mark switchTo() deprecated. (85e0a01ec). `GracefulSwitchLoadBalancer` now receives its configuration like a regular load balancer.
  * binder: Introduce `AllowSecurityPolicy` to allow calling code to not have to wait on async/slow implementations. `BinderTransport` now submits async implementations to an executor. (#11272) (7fee6a3fe)
  * api: Add convenience method in `ServerBuilder` for adding a list of service implementations to the handler registry together. (#11285) (85ed05300)


  ### Improvements
  * examples: Improve example Bazel WORKSPACE to demonstrate referencing grpc-xds. (5ec0187e2)
  * examples: Include Bazel bzlmod configuration (36e687f9d). There are now examples for both non-bzlmod and bzlmod.
  * core: Fixes to `PickFirstLeafLoadBalancer`
    * Eliminate NPE after recovering from a temporary name resolution failure. (#11298)
    * Deduplicate addresses. (#11342, #11345)
  * core: Change default to use the new pick first load balancer (PickFirstLeafLoadBalancer). (#11348)
  * core: Use retryThrottling from defaultServiceConfig when the name resolver config doesn't provide this config. (#11274) (062ebb4d7)
  * netty: Enable use of Netty 4.1.111 by avoiding the optimization provided by `NettyAdaptiveCumulator` if Netty is on version 4.1.111 or later. (#11367)
  * binder: Set a default connect timeout of 60 seconds. (#11359) (21dec3092)
  * binder: Make `BinderServer` own `ServerAuthInterceptor`'s executor that helps avoid leaks. (#11293) (15ad9f546)
  * services:: Added `ProtoReflectionServiceV1` for the v1 reflection protocol. The preexisting `ProtoReflectionService` implements the v1alpha reflection protocol. (#11237) (0aa976c4e)
  
  ### Bug Fixes
  * binder: Add missing synchronization to prevent races when calling awaitTermination(). (#11277) (14fd81f59) 
  * util: Fix `AdvancedTlsX509TrustManager` validation on servers when using SSLSocket. Previously it would try to use a null SSLEngine . (dcb1c018c)

  ### Dependencies
  * compiler: Upgrade from CentOS 7 to AlmaLinux 8 for the pre-compiled Linux protoc-gen-grpc-java (71eb5fb9f). This adds a runtime dependency on libstdc++
  * Upgrade animal-sniffer-annotations to 1.24 (a97738518)
  * Upgrade error_prone_annotations to 2.28.0 (a97738518)
  * Upgrade proto-google-common-protos to 2.41.0 (a97738518)
  * Upgrade google-auth-library to 1.23.0 (a97738518)
  * Upgrade gson to 2.11.0 (a97738518)
  * Upgrade guava to 33.2.1 (a97738518)
  * Upgrade opentelemetry to 1.40.0 (a97738518)
  * Upgrade perfmark-api to 0.27.0 (a97738518)
  * Upgrade protobuf-java to 3.25.3 (a97738518)
  * xds: Remove unused opencensus-proto dependency (e7c3803b5)
  * bazel: Replace `@com_github_cncf_udpa` usage with preexisting `@com_github_cncf_xds`; delete `@com_github_cncf_udpa` repo alias for xds (6dd6ca9f9)
  * bazel: Upgrade envoyproxy/data-plane-api to 1611a730 (c540993aa). The version used by Gradle had been updated in 1.62.0 (68334a01), but the bazel version had not
  * bazel: Use com_google_protobuf instead of com_google_protobuf_javalite (7a25e6895). Bazel’s protobuf rules no longer use the old com_google_protobuf_javalite repository name
  * bazel: Don't require protobuf to be in maven_install (d3c2f5a2d). Protobuf’s targets are generally just used directly; this fixed the only place that used maven’s `artifact()` syntax

  ### Thanks to

  @hlx502 
  @erm-g
  @jdcormie
  @JoaoVitorStein
  @cfredri4 



  ---

  ## Version 1.67.1

  ## gRPC Java 1.67.1 Release Notes

  There was no 1.67.0 release. There was a problem making the release and it went to Maven Central as 1.68.0 instead. This is a version-corrected release.

  ### Improvements

  * Petiole load balancing policies (e.g., round\_robin, weighted\_round\_robin, ring\_hash, least\_request) had internal refactorings. This should not have changed their behavior  
  * api: Introduce onResult2 in NameResolver Listener2 that returns Status (90d0fabb1)
  * core: touch() buffer when detach()ing (e821d5e15). This makes it clearer whether a leak is a gRPC leak or an application leak when the Detachable API is being used  
  * example: delete duplicate and unused code in KeepAliveClient.java (6a9bc3ba1)  
  * example: Added Dualstack example (\#11451) (72a977bf7)  
  * stub: Add newAttachMetadataServerInterceptor() MetadataUtil (\#11458) (6dbd1b9d5)
  * xds: Separate xds clients for each channel target, each with its own connection to an xds server. (\#11484) (d034a56cb)  
  * xds: Envoy proto sync to 2024-07-06 (\#11401) (96a788a34)  
  * xds: cncf/xds proto sync to 2024-07-24 (\#11417) (0017c98f6)  
  * xds: Import RLQS protos (\#11418) (c29763d88)  
  * xds: ClusterManagerLB must update child configuration (10d6002cb). Previously, RLS configuration would not have been updated  

  ### Bug Fixes

  * core: Revert "Enable new PickFirst LB (\#11348)" (\#11425) (cc1cbe987)  
  * rls: Fix log statements incorrectly referring to "LRS" (\#11497) (c63e35488)
  * util: Stop using SocketAddress.toString() for checking address equality (f866c805c). This change applies to all petiole load balancing policies. For regular usages that use dns name resolution, this is unlikely to matter as the default dns name resolver returns consistent addresses. But this might improve LB behavior for some custom load balancers  
  * xds: Fix load reporting when pick first is used for locality-routing. (\#11495) (1dae144f0)  
  * xds: Fix NullPointerException introduced in "Fix load reporting when pick first is used for locality-routing" (#11553). This change is not present in 1.68.0
  * xds: XdsClient should unsubscribe on last resource (\#11264) (448ec4f37)  

  ### Dependencies

  * Upgrade Netty to 4.1.110 and tcnative to 2.0.65 (\#11444) (70ae83288)  
  * examples: Upgrade Maven plugin versions (75012a5be)  
  * Remove direct dependency on j2objc (ff8e41376)

  ### Thanks to
  @Juneezee
  @lujiajing1126
  @JarvisCraft
  @sunpe


  ---

  ## Version 1.68.0

  This was supposed to be v1.67.0, but there was a mistake during the release process. This has everything in v1.67.1, _except_ for:
  * xds: Fix NullPointerException introduced in "Fix load reporting when pick first is used for locality-routing" (https://github.com/grpc/grpc-java/pull/11553)

  ---

  ## Version 1.68.1

  v1.68.0 was a mistake. This is the first release of version 1.68.x

  ### Bug Fixes

  * xds: Fix NullPointerException introduced in "Fix load reporting when pick first is used for locality-routing" (\#11553). This was in 1.67.1 but not 1.68.0

  ### Behavior Changes

  * core: JSON parsing rejects duplicate keys in objects (\#11575) (4be69e3f8). This is the existing behavior in C core. Duplicate keys in objects are dangerous as which value takes effect is undefined. Previously, the last value was used  
  * okhttp: Detect transport executors with no remaining threads (\#11503) (3a6be9ca1). The transport uses two threads, but one is on-demand. If the executor provided to `builder.transportExecutor()` runs out of threads (e.g., it is a fixed-size thread pool), *all* transports can be wedged, unable to run on-demand tasks, until keepalive kills one of them. Two threads are now used when handshaking a new transport, and the transport will time out after 1 second with “Timed out waiting for second handshake thread” if two threads are unavailable  
  * gcp-csm-o11y: Get  `mesh_id` value from `CSM_MESH_ID` environment variable, instead of getting it from bootstrap file (84d30afad)

  ### Improvements

  * New grpc-context-override-opentelemetry artifact (\#11523) (782a44ad6) (\#11599) (e59ae5fad). This is a `io.grpc.Context` storage override to store its state in `io.opentelemetry.context.Context`. Libraries should not add a dependency on this artifact, as applications can only have one storage override in their classpath  
  * New grpc-s2a artifact. It is a transport that offloads the handshake similar to ALTS, but for TLS. It provides `io.grpc.s2a.S2AChannelCredentials`  
  * api: Enhance name resolver \`ResolutionResult\` to hold addresses or error so the single listener API *onResult2* is used to convey both success and error cases for name resolution (\#11330) (1ded8aff8)  
  * core: Handle NameResolver/LoadBalancer exceptions when panicking (b692b9d26). This expands the class of bugs that will fail RPCs with the panic error, versus some undefined behavior  
  * core: Use the default service config in case of initial name resolver address resolution error (\#11577) (fa26a8bc5)  
  * core: `StreamTracer.inboundMessageRead()` now reports uncompressed message size when the message does not need compression (\#11598) (2aae68e11). Previously it always reported `-1` (unknown)  
  * netty: Avoid TCP\_USER\_TIMEOUT warning when explicitly specifying a non-epoll channel type to use (\#11564) (62f409810)  
  * okhttp: Don't warn about missing Conscrypt (6f3542297). This is especially helpful when using TLS but not running on Android  
  * android: For `UdsChannelBuilder`, use fake IP instead of localhost (a908b5e40). This avoids an unnecessary DNS lookup  
  * xds: Add xDS node ID in select control plane errors to enable cross-referencing with control plane logs when debugging (f3cf7c3c7)  
  * xds: Enhanced how ADS stream terminations are handled, specifically addressing cases where a response has or hasn't been received (\#2e9c3e19f)  
  * binder: Update status code documentation for Android 11's package visibility rules. (\#11551) (99be6e985)  
  * binder: Update binderDied() error description to spell out the possibilities for those unfamiliar with Android internals. (\#11628) (46c1b387f)  
  * example-gauth: Use application default creds instead of file argument (\#11595) (94a0a0d1c)
  * opentelemetry: Experimental OpenTelemetry tracing is available. Set the `GRPC_EXPERIMENTAL_ENABLE_OTEL_TRACING` environment variable to `true` to enable tracing support in `GrpcOpenTelemetry` (\#11409, \#11477)(043ba55, 421e237)

  ### Dependencies

  * Updated protobuf-java to 3.25.5. This helps avoid CVE-2024-7254 (2ff837ab6)

  Thanks to:  
  @Juneezee  
  @lgalfaso  
  @bestbeforetoday  
  @hlx502  
  @JoeCqupt

  ---

  ## Version 1.68.2

  ## Bug Fixes
  * api: When forwarding from Listener onAddresses to Listener2 continue to use onResult (https://github.com/grpc/grpc-java/pull/11688). This fixes a 1.68.1 "IllegalStateException: Not called from the SynchronizationContext" regression (#11662) that could be seen in certain custom NameResolvers
  * okhttp: If the frame handler thread is null do not schedule it on the executor (https://github.com/grpc/grpc-java/pull/11716). This fixes a 1.68.1 NullPointerException regression when a custom transportExecutor was provided to the channel and it did not have enough threads to run new tasks

  ## Improvements
  * examples: Use xds-enabled server and xds credentials in example-gcp-csm-observability (https://github.com/grpc/grpc-java/pull/11707)

  ---

  ## Version 1.68.3

  ## Bug Fixes

  * okhttp: Improve certificate handling by rejecting non-ASCII subject alternative names and hostnames as seen in CVE-2021-0341 (\#11749) (a0982ca0a). Hostnames are considered trusted and CAs are required to use punycode for non-ASCII hostnames, so this is expected to provide defense-in-depth. See also the [related GoSecure blog post](https://gosecure.ai/blog/2020/10/27/weakness-in-java-tls-host-verification/) and the [AOSP fix](https://android.googlesource.com/platform/external/okhttp/+/ddc934efe3ed06ce34f3724d41cfbdcd7e7358fc)
  * xds: Preserve nonce when unsubscribing last watcher of a particular type so that new discovery requests of that type are handled correctly (1cf1927d1). This (along with 6c12c2bd2) fixes a nonce-handling regression introduced in 1.66.0 that could cause resources to appear to not exist until re-creating the ADS stream. Triggering the behavior required specific config changes. It is easiest to trigger when clusters use EDS and routes are changed from one cluster to another. The error “found 0 leaf (logical DNS or EDS) clusters for root cluster” might then be seen
  * xds: Remember nonces for unknown types (6c12c2bd2)
  * xds: Unexpected types in the bootstrap’s server_features should be ignored (e8ff6da2c). They were previously required to be strings
  * xds: Fixed unsupported unsigned 32 bits issue for circuit breaker (#11735) (f8f613984). This fixes clients treating large max_requests as “no requests” and failing all requests


  ---

  ## Version 1.69.0

  **v1.69.0**

  New Features

  * api: Allow `LoadBalancer`s to specify an authority per-RPC.(\#11631) (c167ead85) CallOptions.withAuthority() has higher precedence.  
  * netty: Add soft Metadata size limit enforcement. (\#11603) (735b3f3fe) The soft limit is a lower size limit that fails an increasing percentage of RPCs as the Metadata size approaches the upper limit. This can be used as an “early warning” that the Metadata size is growing too large  
  * alts: support altsCallCredentials in `GoogleDefaultChannelCredentials` (\#11634) (ba8ab796e)  
  * xds: Add grpc.xds\_client metrics, as documented by [OpenTelemetry Metrics](https://grpc.io/docs/guides/opentelemetry-metrics/#xdsclient-instruments) (\#11661) (20d09cee5). `grpc.xds.authority` is not yet available

  Bug Fixes

  * api: When forwarding from `Listener` onAddresses to `Listener2` continue to use onResult (\#11666) (dae078c0a). This fixes a 1.68.1 "IllegalStateException: Not called from the SynchronizationContext" regression (\#11662) that could be seen in certain custom NameResolvers  
  * okhttp: If the frame handler thread is null do not schedule it on the executor (ef1fe8737). This fixes a 1.68.1 NullPointerException regression when a custom transportExecutor was provided to the channel and it did not have enough threads to run new tasks

  Improvements

  * api: Add `java.time.Duration` overloads to `CallOptions`, `AbstractStub` methods that take TimeUnit and a time value (\#11562) (766b92379)  
  * core: Make timestamp usage in Channelz use nanos from Java.time.Instant when available (\#11604) (9176b5528). This increases the timestamp precision from milliseconds  
  * okhttp: Fix for ipv6 link local with scope (\#11725[) (e98e7445b)](https://github.com/grpc/grpc-java/commit/e98e7445be6209ed4300724d6c2769635ceef5e4)  
  * binder: Let `AndroidComponentAddress` specify a target UserHandle (\#11670) (e58c998a4)  
  * servlet: Deframe failures should be logged on the server as warnings (\#11645) (a5db67d0c)  
  * s2a: Rename the Bazel target s2av2\_credentials to s2a (29dd9bad3). The target s2a had been referenced by IO\_GRPC\_GRPC\_JAVA\_OVERRIDE\_TARGETS but didn’t previously exist  
  * services: Make channelz work with proto lite (\#11685) (b1703345f). This compatibility is on the source level. There is not a pre-built binary on Maven Central that supports proto lite  
  * services: Deprecate ProtoReflectionService (\#11681) (921f88ae3). The class implements the deprecated v1alpha of the reflection protocol. Prefer ProtoReflectionServiceV1, which implements the v1 version of the reflection protocol

  Dependencies

  * Upgrade proto-google-common-protos to 2.48.0 (1993e68b0)  
  * Upgrade google-auth-library to 1.24.1 (1993e68b0)  
  * Upgrade error\_prone\_annotations to 2.30.0 (1993e68b0)  
  * Upgrade Guava to 33.3.1-android (1993e68b0)  
  * Upgrade opentelemetry-api to 1.43.0 (1993e68b0)  
  * xds: Remove Bazel dependency on xds v2 (664f1fcf8). This had been done for the Maven Central binaries in 1.63.0, but had been missed for Bazel builds

  Documentation

  * binder: Update error codes doc for new "Safer Intent" rules. (\#11639) (fe350cfd5)  
  * examples: Use xds-enabled server and xds credentials in example-gcp-csm-observability (\#11706) (a79982c7f)

  Thanks to  
  [@niloc132](https://github.com/niloc132)  
  [@rockspore](https://github.com/rockspore)  
  [@SreeramdasLavanya](https://github.com/SreeramdasLavanya)  
  [@vinodhabib](https://github.com/vinodhabib)

  ---

  ## Version 1.69.1

  ## Bug Fixes

  * okhttp: Improve certificate handling by rejecting non-ASCII subject alternative names and hostnames as seen in CVE-2021-0341 (\#11749) (a0982ca0a). Hostnames are considered trusted and CAs are required to use punycode for non-ASCII hostnames, so this is expected to provide defense-in-depth. See also the [related GoSecure blog post](https://gosecure.ai/blog/2020/10/27/weakness-in-java-tls-host-verification/) and the [AOSP fix](https://android.googlesource.com/platform/external/okhttp/+/ddc934efe3ed06ce34f3724d41cfbdcd7e7358fc)
  * xds: Preserve nonce when unsubscribing last watcher of a particular type so that new discovery requests of that type are handled correctly (1cf1927d1). This (along with 6c12c2bd2) fixes a nonce-handling regression introduced in 1.66.0 that could cause resources to appear to not exist until re-creating the ADS stream. Triggering the behavior required specific config changes. It is easiest to trigger when clusters use EDS and routes are changed from one cluster to another. The error “found 0 leaf (logical DNS or EDS) clusters for root cluster” might then be seen
  * xds: Remember nonces for unknown types (6c12c2bd2)
  * xds: Unexpected types in the bootstrap’s server_features should be ignored (e8ff6da2c). They were previously required to be strings
  * xds: Fixed unsupported unsigned 32 bits issue for circuit breaker (#11735) (f8f613984). This fixes clients treating large max_requests as “no requests” and failing all requests
  * xds: Remove xds authority label from metric registration (#11760) (6516c7387). This fixes the error “Incorrect number of required labels provided. Expected: 4” introduced in 1.69.0

  ---

